### PR TITLE
Initiate work on navigation enhancement

### DIFF
--- a/content/editor.html
+++ b/content/editor.html
@@ -17,10 +17,10 @@
 </head>
 <body id="pencildoc" role="application">
 <div id="overflow">
-<a href="#code-editor-canvas" aria-label="skip to programming workspace" class="skip">Skip to programming workspace</a>
 <div id="overlay"></div>
 <div id="notification"><div><div></div></div></div>
 <div id="middle"><div></div></div>
+<a href="#code-editor-canvas" aria-label="skip to programming workspace" class="skip">Skip to programming workspace</a>
 <table id="top" width="100%"><tr><td id="topleft"><nobr>
 <script>
 (function(){

--- a/content/editor.html
+++ b/content/editor.html
@@ -50,7 +50,7 @@ pencilcode.owner,
 pencilcode.domain,
 '/image/folder_32.png',
 '" height="32" width="32"></a>',
-'<span role="textbox" id="filename" aria-label="Edit to move or rename" title="Edit to move or rename" style="user-select:text;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text">',
+'<span role="textbox" id="filename" aria-label="Edit to move or rename project" title="Edit to move or rename project" style="user-select:text;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text">',
 htmlEscape(location.pathname.replace(/^\/(?:[^\/]*\/)?|\/$/g, '')),
 '</span>'].join(''));
 })();

--- a/content/editor.html
+++ b/content/editor.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" type="text/css" href="//<!--#echo var="site"-->/lib/font-awesome.css">
 <link rel="stylesheet" type="text/css" href="//<!--#echo var="site"-->/lib/tooltipster/css/tooltipster.css">
 </head>
-<body id="pencildoc">
+<body id="pencildoc" role="application">
 <div id="overflow">
 <a href="#code-editor-canvas" aria-label="skip to programming workspace" class="skip">Skip to programming workspace</a>
 <div id="overlay"></div>

--- a/content/editor.html
+++ b/content/editor.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" type="text/css" href="//<!--#echo var="site"-->/lib/tooltipster/css/tooltipster.css">
 </head>
 <body id="pencildoc">
-<a href="#maincontent" class="skip">Skip to code editor</a>
 <div id="overflow">
+<a href="#code-editor-canvas" aria-label="skip to programming workspace" class="skip">Skip to programming workspace</a>
 <div id="overlay"></div>
 <div id="notification"><div><div></div></div></div>
 <div id="middle"><div></div></div>
@@ -43,13 +43,13 @@ window.preload = function(data) {
 function htmlEscape(s){return s.replace(
   /[<>&]/g,function(c){return c=='<'?'&lt;':c =='>'?'&gt;':'&amp;';});}
 document.write([
-'<a href="/edit/"><span id="owner" title="Top directory">',
+'<a href="/edit/"><span id="owner" title="Top directory" aria-label="Top directory">',
 pencilcode.owner,
-'</span></a><a href="../"><img id="folder" title="Parent directory" src="//',
+'</span></a><a href="../"><img aria-label="Parent directory" id="folder" title="Parent directory" src="//',
 pencilcode.domain,
 '/image/folder_32.png',
 '" height="32" width="32"></a>',
-'<span id="filename" title="Edit to move or rename" style="user-select:text;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text">',
+'<span role="textbox" id="filename" aria-label="Edit to move or rename" title="Edit to move or rename" style="user-select:text;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text">',
 htmlEscape(location.pathname.replace(/^\/(?:[^\/]*\/)?|\/$/g, '')),
 '</span>'].join(''));
 })();

--- a/content/editor.html
+++ b/content/editor.html
@@ -20,6 +20,7 @@
 <div id="overlay"></div>
 <div id="notification"><div><div></div></div></div>
 <div id="middle"><div></div></div>
+<div id="focus-guide" style="width:0px; height:0px;" tabindex="0"></div>
 <a href="#code-editor-canvas" aria-label="skip to programming workspace" class="skip">Skip to programming workspace</a>
 <table id="top" width="100%"><tr><td id="topleft"><nobr>
 <script>

--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -1,15 +1,30 @@
 function a11yController() {
     this.init();
-    this.addARIAlabels();
+    this.addARIAattributes(); 
 }
 
-a11yController.prototype.addARIAlabels = function () {
+a11yController.prototype.addARIAattributes = function () {
+    //run button label
+    var runButton = document.querySelector('#run')
+    runButton.setAttribute('aria-label', 'run program')
+    
     //add labels to banner buttons
+    var banner = document.getElementById('top')
+    banner.setAttribute('role', 'banner')
     var bannerBtnContainer = document.querySelector('#topright')
     var bannerBtns = bannerBtnContainer.querySelectorAll("#save, #screenshot, #share, #login, #help, #guide, #splitscreen")
     bannerBtns.forEach(function(element) {
         element.setAttribute('aria-label', element.id);
     }, this);
+
+    //block palette 
+    var blockPalette = document.querySelector('.droplet-palette-element')
+    blockPalette.setAttribute('role', 'region')
+    blockPalette.setAttribute('aria-label', 'block palette')
+
+    var blockEditor = document.querySelector('.droplet-main-scroller')
+    blockEditor.setAttribute('role', 'region')
+    blockPalette.setAttribute('aria-label', 'block editor')
 }
 
 a11yController.prototype.init = function () {
@@ -21,8 +36,16 @@ a11yController.prototype.init = function () {
     
     document.querySelector('.droplet-main-canvas').setAttribute('id', 'code-editor-canvas')
     document.querySelector('.droplet-main-canvas').setAttribute('tabindex', 0)
+    document.querySelector('.droplet-hidden-input').setAttribute('tabindex', -1)
+    var textInput = document.querySelector('.ace_text-input')
+    textInput.addEventListener("focus", function() {
+        console.log('focused');
+        document.querySelector('#run').focus()
+    });
 
-    document.activeElement.blur(); //set focus to body of view
+    console.log(textInput)
+    textInput.blur();
+    textInput.focus();
 }
 
 a11yController.prototype.tabController = function (event) {

--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -25,6 +25,11 @@ a11yController.prototype.addARIAattributes = function () {
     var blockEditor = document.querySelector('.droplet-main-scroller')
     blockEditor.setAttribute('role', 'region')
     blockPalette.setAttribute('aria-label', 'block editor')
+
+    var blockToggle = document.querySelector('.blocktoggle')
+    var textToggle = document.querySelector('.texttoggle')
+    blockToggle.setAttribute('role', 'button')
+    textToggle.setAttribute('role', 'button')
 }
 
 a11yController.prototype.init = function () {
@@ -38,14 +43,15 @@ a11yController.prototype.init = function () {
     document.querySelector('.droplet-main-canvas').setAttribute('tabindex', 0)
     document.querySelector('.droplet-hidden-input').setAttribute('tabindex', -1)
     var textInput = document.querySelector('.ace_text-input')
-    textInput.addEventListener("focus", function() {
-        console.log('focused');
-        document.querySelector('#run').focus()
-    });
-
-    console.log(textInput)
+    textInput.addEventListener("focus", initFocus);
     textInput.blur();
     textInput.focus();
+
+    function initFocus() {
+        console.log('focused');
+        document.querySelector('#run').focus()
+        textInput.removeEventListener("focus", initFocus)
+    }
 }
 
 a11yController.prototype.tabController = function (event) {

--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -1,6 +1,15 @@
 function a11yController() {
-    //this.primaryNavSections = this.setupPrimaryNav();
     this.init();
+    this.addARIAlabels();
+}
+
+a11yController.prototype.addARIAlabels = function () {
+    //add labels to banner buttons
+    var bannerBtnContainer = document.querySelector('#topright')
+    var bannerBtns = bannerBtnContainer.querySelectorAll("#save, #screenshot, #share, #login, #help, #guide, #splitscreen")
+    bannerBtns.forEach(function(element) {
+        element.setAttribute('aria-label', element.id);
+    }, this);
 }
 
 a11yController.prototype.init = function () {

--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -1,37 +1,41 @@
 function a11yController() {
+    this.runButton = document.querySelector('#run')
+    this.banner = document.getElementById('top')
+    this.blockPalette = document.querySelector('.droplet-palette-wrapper')
+    this.bannerBtnContainer = document.querySelector('#topright')
+    this.bannerBtns = this.bannerBtnContainer.querySelectorAll("#save, #screenshot, #share, #login, #help, #guide, #splitscreen")    
+    this.blockEditor = document.querySelector('.droplet-wrapper-div')
+    this.blockToggle = document.querySelector('.blocktoggle')
+    this.textToggle = document.querySelector('.texttoggle')
+    
     this.init();
     this.addARIAattributes(); 
 }
 
+//give elements the proper aria attributes
 a11yController.prototype.addARIAattributes = function () {
     //run button label
-    var runButton = document.querySelector('#run')
-    runButton.setAttribute('aria-label', 'run program')
-    
+    this.runButton.setAttribute('aria-label', 'run program') //TODO: bug where run button is recreated on toggle
+
     //add labels to banner buttons
-    var banner = document.getElementById('top')
-    banner.setAttribute('role', 'banner')
-    var bannerBtnContainer = document.querySelector('#topright')
-    var bannerBtns = bannerBtnContainer.querySelectorAll("#save, #screenshot, #share, #login, #help, #guide, #splitscreen")
-    bannerBtns.forEach(function(element) {
+    this.bannerBtns.forEach(function(element) {
         element.setAttribute('aria-label', element.id);
     }, this);
 
-    //block palette 
-    var blockPalette = document.querySelector('.droplet-palette-element')
-    blockPalette.setAttribute('role', 'region')
-    blockPalette.setAttribute('aria-label', 'block palette')
+    //block palette
+    this.blockPalette.setAttribute('role', 'region')
+    this.blockPalette.setAttribute('aria-label', 'block palette')
 
-    var blockEditor = document.querySelector('.droplet-main-scroller')
-    blockEditor.setAttribute('role', 'region')
-    blockPalette.setAttribute('aria-label', 'block editor')
+    //block editor
+    this.blockEditor.setAttribute('role', 'region')
+    this.blockEditor.setAttribute('aria-label', 'block editor')
 
-    var blockToggle = document.querySelector('.blocktoggle')
-    var textToggle = document.querySelector('.texttoggle')
-    blockToggle.setAttribute('role', 'button')
-    textToggle.setAttribute('role', 'button')
+    //editor mode toggle (they made two of them for some reason)
+    this.blockToggle.setAttribute('role', 'button')
+    this.textToggle.setAttribute('role', 'button')
 }
 
+//remove focus from elements that shouldn't have focus
 a11yController.prototype.init = function () {
     //remove iframes from tab index
     var iframes = document.querySelectorAll('iframe');    
@@ -39,6 +43,8 @@ a11yController.prototype.init = function () {
         element.setAttribute("tabindex", -1);
     }, this);
     
+    //an attemp to remove focus from the text editor on load
+    //this allows the user to reach the skip to editor link after hitting tab once
     document.querySelector('.droplet-main-canvas').setAttribute('id', 'code-editor-canvas')
     document.querySelector('.droplet-main-canvas').setAttribute('tabindex', 0)
     document.querySelector('.droplet-hidden-input').setAttribute('tabindex', -1)
@@ -46,7 +52,6 @@ a11yController.prototype.init = function () {
     textInput.addEventListener("focus", initFocus);
     textInput.blur();
     textInput.focus();
-
     function initFocus() {
         console.log('focused');
         console.log(document.getElementById('focus-guide'))
@@ -55,6 +60,7 @@ a11yController.prototype.init = function () {
     }
 }
 
+//old code left for reference
 a11yController.prototype.tabController = function (event) {
     if(event.keyCode == 9) {
         //SHIFT + TAB 
@@ -73,6 +79,7 @@ a11yController.prototype.tabController = function (event) {
     }
 }
 
+//old code left for reference
 a11yController.prototype.setupPrimaryNav = function () {
     //main ui sections
     var blockEditor = document.querySelector('.droplet-main-scroller')

--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -1,22 +1,19 @@
 function a11yController() {
-    this.primaryNavSections = this.setupPrimaryNav();
+    //this.primaryNavSections = this.setupPrimaryNav();
     this.init();
 }
 
 a11yController.prototype.init = function () {
-    document.activeElement.blur(); //set focus to body of view     
-    
-    //set target for skip link
-    document.getElementsByClassName("droplet-wrapper-div")[0].setAttribute("id", "maincontent");
-    
     //remove iframes from tab index
     var iframes = document.querySelectorAll('iframe');    
     iframes.forEach(function(element) {        
         element.setAttribute("tabindex", -1);
-    }, this);        
+    }, this);
+    
+    document.querySelector('.droplet-main-canvas').setAttribute('id', 'code-editor-canvas')
+    document.querySelector('.droplet-main-canvas').setAttribute('tabindex', 0)
 
-    //intercept keyboard events
-    document.addEventListener('keydown', this.tabController);
+    document.activeElement.blur(); //set focus to body of view
 }
 
 a11yController.prototype.tabController = function (event) {

--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -14,6 +14,9 @@ function a11yController() {
 
 //give elements the proper aria attributes
 a11yController.prototype.addARIAattributes = function () {
+    //top bar
+    this.banner.setAttribute('role', 'banner')
+    
     //run button label
     this.runButton.setAttribute('aria-label', 'run program') //TODO: bug where run button is recreated on toggle
 

--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -49,7 +49,8 @@ a11yController.prototype.init = function () {
 
     function initFocus() {
         console.log('focused');
-        document.querySelector('#run').focus()
+        console.log(document.getElementById('focus-guide'))
+        document.getElementById('focus-guide').focus()
         textInput.removeEventListener("focus", initFocus)
     }
 }

--- a/content/src/accessibility.js
+++ b/content/src/accessibility.js
@@ -1,2 +1,0 @@
-//This is a test pineapple.
-

--- a/content/welcome.html
+++ b/content/welcome.html
@@ -110,7 +110,7 @@ Contribute to the development of Pencil Code at
 an editor that lets you work in either blocks or text.
 Create art, music, games, and stories. Or
 invent a program that will change the world.
-<p style="text-align:center"><a class="btn btn-primary" style="font-size:133%" href="/edit/first">Let's play!</a>
+<p style="text-align:center"><a aria-label="pencil code code editor" class="btn btn-primary" style="font-size:133%" href="/edit/first">Let's play!</a>
 </div>
 <div class="col-sm-6 vpadding">
 <iframe id="demo" style="min-height:300px;height:100%;width:100%;border:0" tabindex="-1"></iframe>


### PR DESCRIPTION
After spending a lot of time trying to make our own tab controller, we decided it would be easier to add appropriate aria roles to each section of the page. For example, the top bar now has a role of banner and the editor has a role of region. These roles make it easier for VoiceOver to differentiate between each section and reveal the sections in the Web Rotor. 
![screen shot 2017-04-18 at 2 06 15 pm](https://cloud.githubusercontent.com/assets/6683238/25148400/69979094-2440-11e7-80d4-daabd9685c5b.png)
