### PR TITLE
add presentation role to output area

### DIFF
--- a/content/lib/a11yLib.js
+++ b/content/lib/a11yLib.js
@@ -36,6 +36,12 @@ a11yController.prototype.addARIAattributes = function () {
     //editor mode toggle (they made two of them for some reason)
     this.blockToggle.setAttribute('role', 'button')
     this.textToggle.setAttribute('role', 'button')
+
+    //presentation area
+    var outputFrame = document.querySelector('#output-frame')
+    var outputDocument = outputFrame.contentDocument || outputFrame.contentWindow.document
+    outputDocument.body.getElementsByClassName('turtlefield')[1].setAttribute('role', 'presentation');
+
 }
 
 //remove focus from elements that shouldn't have focus


### PR DESCRIPTION
According to the WAI-ARIA spec, the presentation role is meant for "An element whose content is completely presentational (like a spacer image, decorative graphic, or clearing element)" We believe the output area falls under this criteria. 